### PR TITLE
Refinery queue, left drop

### DIFF
--- a/Source/BuildOrder.cpp
+++ b/Source/BuildOrder.cpp
@@ -171,7 +171,8 @@ void insanitybot::BuildOrder::SKTerran(InformationManager & _infoManager)
 		}
 	}
 
-	if (hasAcademy && _infoManager.getNumTotalUnit(BWAPI::UnitTypes::Terran_Refinery) < _infoManager.numGeyserBases())
+	if (hasAcademy && _infoManager.getNumTotalUnit(BWAPI::UnitTypes::Terran_Refinery) < _infoManager.numGeyserBases() &&
+		_infoManager.getNumFinishedUnit(BWAPI::UnitTypes::Terran_Command_Center) >= _infoManager.numGeyserBases())
 	{
 		_queue.push_back(BWAPI::UnitTypes::Terran_Refinery);
 		_infoManager.setReservedMinerals(_infoManager.getReservedMinerals() + BWAPI::UnitTypes::Terran_Refinery.mineralPrice());
@@ -331,7 +332,8 @@ void insanitybot::BuildOrder::Nuke(InformationManager & _infoManager)
 		_infoManager.setReservedGas(_infoManager.getReservedGas() + BWAPI::UnitTypes::Terran_Nuclear_Missile.gasPrice());
 	}
 
-	if (hasAcademy && _infoManager.getNumTotalUnit(BWAPI::UnitTypes::Terran_Refinery) - _infoManager.getOwnedIslandBases().size() < _infoManager.numGeyserBases())
+	if (hasAcademy && _infoManager.getNumTotalUnit(BWAPI::UnitTypes::Terran_Refinery) - _infoManager.getOwnedIslandBases().size() < _infoManager.numGeyserBases() &&
+		_infoManager.getNumFinishedUnit(BWAPI::UnitTypes::Terran_Command_Center) >= _infoManager.numGeyserBases())
 	{
 		_queue.push_back(BWAPI::UnitTypes::Terran_Refinery);
 		_infoManager.setReservedMinerals(_infoManager.getReservedMinerals() + BWAPI::UnitTypes::Terran_Refinery.mineralPrice());

--- a/Source/UnitManager.cpp
+++ b/Source/UnitManager.cpp
@@ -2248,8 +2248,8 @@ const BWAPI::Position & insanitybot::UnitManager::waypoint(int i)
 void insanitybot::UnitManager::calculateWaypoints()
 {
 	// Tile coordinates.
-	int minX = 0;
-	int minY = 0;
+	int minX = 1;
+	int minY = 1;
 	int maxX = BWAPI::Broodwar->mapWidth() - 1;
 	int maxY = BWAPI::Broodwar->mapHeight() - 1;
 


### PR DESCRIPTION
Fix for refineries being queued improperly on bio builds before the natural was done. Hopeful fix for dropships being stuck on the left side of the map.